### PR TITLE
stopped exposing port 80 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ LABEL author="Max Besley" \
 
 COPY ./infra/nginx/personal-website.conf /etc/nginx/conf.d/
 
-EXPOSE 443 80
+EXPOSE 443
 


### PR DESCRIPTION
Stopped using the non-secure HTTP protocol since port 80 needs to be free for certificate renewal.